### PR TITLE
Added encoder simulation, removed RPY2Quat in favor of mujoco impleme…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 glfw == 2.6.2
-mujoco >= 3.0.0
+mujoco >= 3.1.5
 pin
 transitions
 ahrs


### PR DESCRIPTION
In this rather small PR I have:
- Enabled encoder simulation if
```
simulation:
  simulate_encoders: True
```
is set in driver file.
- Removed some functions in favor of Mujoco implementation
- Renamed `nannoseconds` -> `dt`

Goes with -> https://github.com/ajsmilutin/robot_properties_solo/pull/5